### PR TITLE
add origin checks for heroku and bare domain name

### DIFF
--- a/apps/bear_necessities_web/config/prod.exs
+++ b/apps/bear_necessities_web/config/prod.exs
@@ -20,6 +20,11 @@ config :bear_necessities_web, BearNecessitiesWeb.Endpoint,
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json",
   secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
+  check_origin: [
+    "https://bear-necessities.herokuapp.com",
+    "https://unbearable.nl",
+    "https://www.unbearable.nl"
+  ],
   live_view: [
     signing_salt: Map.fetch!(System.get_env(), "LIVE_VIEW_SALT")
   ]

--- a/apps/bear_necessities_web/test/bear_necessities_web/views/error_view_test.exs
+++ b/apps/bear_necessities_web/test/bear_necessities_web/views/error_view_test.exs
@@ -9,6 +9,7 @@ defmodule BearNecessitiesWeb.ErrorViewTest do
   end
 
   test "renders 500.html" do
-    assert render_to_string(BearNecessitiesWeb.ErrorView, "500.html", []) == "Internal Server Error"
+    assert render_to_string(BearNecessitiesWeb.ErrorView, "500.html", []) ==
+             "Internal Server Error"
   end
 end


### PR DESCRIPTION
this makes sure that websocket connections will work for all listed
domain names.