### PR TITLE
Use player_pid for Player actions

### DIFF
--- a/apps/bear_necessities_web/lib/bear_necessities_web/live/game.ex
+++ b/apps/bear_necessities_web/lib/bear_necessities_web/live/game.ex
@@ -37,7 +37,7 @@ defmodule BearNecessitiesWeb.Game do
 
   def handle_event("start", %{"player" => %{"display_name" => display_name}}, %{id: id} = socket) do
     reference = set_updates(connected?(socket))
-    bear = Player.start(display_name, id)
+    {player_pid, bear} = Player.start(display_name, id)
     viewport = ViewPort.get_viewport(id)
 
     socket =
@@ -49,6 +49,7 @@ defmodule BearNecessitiesWeb.Game do
       |> assign(:autoplay, false)
       |> assign(:pos_y, bear.pos_y)
       |> assign(:bear, bear)
+      |> assign(:player_pid, player_pid)
 
     {:noreply, socket}
   end
@@ -92,10 +93,10 @@ defmodule BearNecessitiesWeb.Game do
     {:noreply, socket}
   end
 
-  def handle_event("key_up", " ", %{id: id} = socket) do
+  def handle_event("key_up", " ", %{id: id, assigns: %{player_pid: player_pid}} = socket) do
     socket =
       socket
-      |> assign(:bear, Player.claw(id))
+      |> assign(:bear, Player.claw(player_pid, id))
       |> assign(:viewport, ViewPort.get_viewport(id))
 
     {:noreply, socket}
@@ -170,8 +171,8 @@ defmodule BearNecessitiesWeb.Game do
     ref
   end
 
-  def move_player(id, direction, socket) do
-    bear = Player.move(id, move_to(direction))
+  def move_player(id, direction, %{assigns: %{player_pid: player_pid}} = socket) do
+    bear = Player.move(player_pid, id, move_to(direction))
 
     viewport = ViewPort.get_viewport(id)
 

--- a/apps/game/lib/player.ex
+++ b/apps/game/lib/player.ex
@@ -8,7 +8,7 @@ defmodule Player do
   defstruct [:id, :claw, :timer_pid]
 
   def start_link(default) when is_list(default) do
-    GenServer.start_link(__MODULE__, default, name: __MODULE__)
+    GenServer.start_link(__MODULE__, default)
   end
 
   @impl true
@@ -72,16 +72,18 @@ defmodule Player do
     {:noreply, state}
   end
 
-  def move(player_id, way) do
-    GenServer.call(Player, {:action, way, player_id})
+  def move(pid, player_id, way) do
+    GenServer.call(pid, {:action, way, player_id})
   end
 
-  def claw(player_id) do
-    GenServer.call(Player, {:claw, player_id})
+  def claw(pid, player_id) do
+    GenServer.call(pid, {:claw, player_id})
   end
 
   def start(display_name, id) do
-    Player.start_link(id: id)
-    Game.create_bear(display_name: display_name, id: id, started: true)
+    {:ok, pid} = Player.start_link(id: id)
+    bear = Game.create_bear(display_name: display_name, id: id, started: true)
+
+    {pid, bear}
   end
 end


### PR DESCRIPTION
Use player_pid instead of name for the start up of a GenServer, so we
start a separate GenServer for every player instad of one for all
players. This is now needed because move and claw affect an individual
player.