### PR TITLE
Rearrange game map and leaderboard

### DIFF
--- a/apps/bear_necessities_web/assets/css/base.css
+++ b/apps/bear_necessities_web/assets/css/base.css
@@ -4,9 +4,9 @@ body {
   background: #363636;
   color: white;
   font-family: "Press Start 2P", Courier, monospace;
-  text-shadow: 2px 2px rgba(0, 0, 0, 0.8);
-  margin: 30px;
   font-size: 16px;
+  margin: 0;
+  text-shadow: 2px 2px rgba(0, 0, 0, 0.8);
 }
 
 h1 {

--- a/apps/bear_necessities_web/assets/css/game/game.css
+++ b/apps/bear_necessities_web/assets/css/game/game.css
@@ -1,12 +1,67 @@
 .game {
+  display: flex;
+  overflow: hidden;
+
+  .main {
+    padding: 10px 30px;
+    flex: 1;
+    overflow: hidden;
+    min-width: calc(100vmin - 13em);
+  }
+
+  .sidebar {
+    padding: 10px 30px;
+    flex-basis: 30px;
+    flex: 0 0 25em;
+    overflow: hidden;
+  }
+
+  .gui {
+    height: 90px;
+    margin-bottom: 30px;
+    text-align: center;
+  }
+
+  .map {
+    border: 6px solid rgba(0, 0, 0, 0.5);
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vmin - 13em);
+    left: 0;
+    margin: auto;
+    right: 0;
+    text-align: center;
+    top: 0;
+    width: calc(100vmin - 13em);
+  }
+
+  .row {
+    display: flex;
+    flex-wrap: nowrap;
+    flex: 1;
+    justify-content: center;
+    justify-content: space-evenly;
+  }
+
+  h1 {
+    height: 1.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .load-bee {
     background-image: url("/images/bees/bees.gif");
   }
+
   .load-bee-1 {
     background-image: url("/images/bees/bees-1.gif");
   }
+
   .bee {
     background-image: url("/images/bees/bees.gif");
+
     &:before {
       content: "";
       display: block;
@@ -20,52 +75,33 @@
       transform: rotate(90deg);
     }
   }
-  .gui {
-    text-align: center;
-    margin-bottom: 30px;
-  }
-
-  .map {
-    border: 6px solid rgba(0, 0, 0, 0.5);
-    display: flex;
-    flex-direction: column;
-    width: 800px;
-    height: 800px;
-    text-align: center;
-    margin: 0 auto;
-  }
-
-  .row {
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: center;
-    justify-content: space-evenly;
-    flex: 1;
-  }
 
   /*
   Tiles of map (terain, border)
   */
   .tile {
     background-size: cover;
-    image-rendering: pixelated;
-    height: 100%;
-    position: relative;
     flex: 1;
+    height: 100%;
+    image-rendering: pixelated;
+    position: relative;
 
     &.grass {
       &-1 {
         background-color: #44d873;
         background-image: url("/images/terain/grass-1.gif");
       }
+
       &-2 {
         background-color: #44d873;
         background-image: url("/images/terain/grass-2.gif");
       }
+
       &-3 {
         background-color: #44d873;
         background-image: url("/images/terain/grass-3.gif");
       }
+
       &-4 {
         background-color: #44d873;
         background-image: url("/images/terain/grass-4.gif");
@@ -82,11 +118,11 @@
   Items that are displayed inside tiles (bears, trees, honey, etc)
   */
   .item {
-    background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;
-    image-rendering: pixelated;
+    background-size: cover;
     height: 100%;
+    image-rendering: pixelated;
     width: 100%;
 
     /*
@@ -108,8 +144,7 @@
     Bears
     */
     &.bear {
-      &.self {
-      }
+      &.self {}
 
       &.opponent {
         filter: grayscale(60%);

--- a/apps/bear_necessities_web/assets/css/game/scoreboard.css
+++ b/apps/bear_necessities_web/assets/css/game/scoreboard.css
@@ -1,28 +1,39 @@
 .scoreboard {
-  text-align: center;
-
   .players {
     list-style: none;
-    margin: 0;
-    padding: 0;
-    max-width: 500px;
-    text-align: left;
     margin: 0 auto;
+    margin: 0;
+    max-width: 500px;
+    padding: 0;
+    text-align: left;
   }
 
   .player {
+    display: flex;
+    width: 100%;
+
     &::before {
-      display: inline-block;
-      content: "";
-      width: 30px;
-      height: 30px;
-      background-size: cover;
       background-image: url("/images/bear/idle.gif");
+      background-size: cover;
+      content: "";
+      display: inline-block;
+      flex: 0 0 30px;
+      height: 32px;
+      margin-right: 16px;
       vertical-align: middle;
+      width: 32px;
     }
 
     &.self {
       color: lime;
+    }
+
+    .player-name {
+      flex: 1;
+      line-height: 1.5em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 }

--- a/apps/bear_necessities_web/lib/bear_necessities_web/templates/layout/app.html.eex
+++ b/apps/bear_necessities_web/lib/bear_necessities_web/templates/layout/app.html.eex
@@ -8,8 +8,12 @@
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
   </head>
   <body>
-    <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-    <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+    <%= if flash_info = get_flash(@conn, :info) do %>
+      <p class="alert alert-info" role="alert"><%= flash_info %></p>
+    <% end %>
+    <%= if flash_error = get_flash(@conn, :error) do %>
+      <p class="alert alert-danger" role="alert"><%= flash_error %></p>
+    <% end %>
 
     <%= render @view_module, @view_template, assigns %>
 

--- a/apps/bear_necessities_web/lib/bear_necessities_web/templates/playfield/scoreboard.html.leex
+++ b/apps/bear_necessities_web/lib/bear_necessities_web/templates/playfield/scoreboard.html.leex
@@ -1,11 +1,11 @@
 <div class="scoreboard">
-  <h1>Contending players</h1>
+  <h1>Leaderboard</h1>
 
   <%= if Enum.any? @players do %>
     <ul class="players">
       <%= for player <- @players do %>
         <li class="player <%= if player.id == @id, do: "self", else: nil %>">
-          <%= player.display_name %> - <%= player.honey %>
+          <div class="player-name"><%= player.display_name %></div><div class="score"> - <%= player.honey %></div>
         </li>
       <% end %>
     </ul>

--- a/apps/bear_necessities_web/lib/bear_necessities_web/templates/playfield/template.html.leex
+++ b/apps/bear_necessities_web/lib/bear_necessities_web/templates/playfield/template.html.leex
@@ -1,37 +1,43 @@
-<%= if @play_sounds do %>
-  <button phx-click="sounds_off" class="button small">Mute</button>
-  <audio src="<%= Routes.static_path(BearNecessitiesWeb.Endpoint, "/sound/game-sound.mp3") %>"  type="audio/mpeg" <%= if @autoplay do %> autoplay <% end %> loop> </audio>
-<% else %>
-  <button phx-click="sounds_on" class="button small">Sound</button>
-<% end %>
-
 <%= if @bear.started do %>
-
   <div class="game">
-    <div class="gui">
-      <h1>Hello, <%= @bear.display_name %></h1>
-      <span>X: <%= @pos_x %></span>
-      <span>Y: <%= @pos_y %></span>
-      <button phx-click="left" class="button small">left</button>
-      <button phx-click="down" class="button small">down</button>
-      <button phx-click="up" class="button small">up</button>
-      <button phx-click="right" class="button small">right</button>
-      <%= if is_nil(@bear.dead) do %>
-        <span phx-keydown="key_move" phx-target="window"></span>
-        <span phx-keyup="key_up" phx-target="window"></span>
-      <% end %>
-    </div>
+    <div class="main">
+      <div class="gui">
+        <h1>Hello, <%= @bear.display_name %></h1>
+        <span>X: <%= @pos_x %></span>
+        <span>Y: <%= @pos_y %></span>
+        <%= if @play_sounds do %>
+          <button phx-click="sounds_off" class="button small">Mute</button>
+          <audio src="<%= Routes.static_path(BearNecessitiesWeb.Endpoint, "/sound/game-sound.mp3") %>"  type="audio/mpeg" <%= if @autoplay do %> autoplay <% end %> loop> </audio>
+        <% else %>
+          <button phx-click="sounds_on" class="button small">Sound</button>
+        <% end %>
 
-    <div class="map">
-      <%= for row <- @viewport do %>
-        <div class="row">
-          <%= for {tile, item} <- row do %>
-            <div class="tile <%= tile_class(tile) %> ">
-              <div class="item <%= item_class(item, @id) %>"></div>
+        <button phx-click="left" class="button small">left</button>
+        <button phx-click="down" class="button small">down</button>
+        <button phx-click="up" class="button small">up</button>
+        <button phx-click="right" class="button small">right</button>
+        <%= if is_nil(@bear.dead) do %>
+          <span phx-keydown="key_move" phx-target="window"></span>
+          <span phx-keyup="key_up" phx-target="window"></span>
+        <% end %>
+      </div>
+
+      <div class="map">
+          <%= for row <- @viewport do %>
+            <div class="row">
+              <%= for {tile, item} <- row do %>
+                <div class="tile <%= tile_class(tile) %> ">
+                  <div class="item <%= item_class(item, @id) %>"></div>
+                </div>
+              <% end %>
             </div>
           <% end %>
-        </div>
-      <% end %>
+      </div>
+
+    </div>
+
+    <div class="sidebar">
+      <%= BearNecessitiesWeb.Playfield.render("scoreboard.html", assigns) %>
     </div>
   </div>
 
@@ -50,12 +56,8 @@
       <%= submit("Start", phx_disable_with: "Starting...", class: "button red") %>
     <% end %>
     <br>
-    <p>
-    Use the Spacebar to claw.
-    </p>
-    <p>
-    Arrow keys to move.
-    </p>
+    <p>Use the Spacebar to claw.</p>
+    <p>Arrow keys to move.</p>
   </div>
 
   <div class="preload-images">
@@ -86,5 +88,3 @@
     </div>
   </div>
 <% end %>
-
-<%= BearNecessitiesWeb.Playfield.render("scoreboard.html", assigns) %>


### PR DESCRIPTION
Use display flex for the map and leaderboard to show next to eachother.
The map will resize according to viewport height and width. Overflow
hidden on the game class will prevent scrollbars from appearing when
playing the game.

Still need to style for mobile viewport widths.

<img width="1599" alt="Screenshot 2019-04-26 at 12 43 13" src="https://user-images.githubusercontent.com/7781165/56802704-0181bd00-6821-11e9-9880-b03519753055.png">
<img width="1234" alt="Screenshot 2019-04-26 at 12 43 24" src="https://user-images.githubusercontent.com/7781165/56802705-0181bd00-6821-11e9-8755-2e336cd61041.png">
<img width="1135" alt="Screenshot 2019-04-26 at 12 43 45" src="https://user-images.githubusercontent.com/7781165/56802706-021a5380-6821-11e9-968c-7dfec9e42566.png">
